### PR TITLE
Automatic ID attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2020-04-25
+
+- Now possible to execute 'show' and 'no' command with out the id attribute. For example, instead of doing 'show device id 123' one can now do 'show device 123' and 'no device id 123' can be replaced with 'no device 123'.
+
 ## 2020-04-24
 
 - If 'show job', 'show job id 0', 'show job id -1' or 'show job id last' is executed we will get the last job and show the result of it.

--- a/cli/command.py
+++ b/cli/command.py
@@ -238,10 +238,6 @@ class CliHandler():
                 attributes = line.rstrip().split(' ')[1:]
                 command = line.split(' ')[0]
 
-        if attributes is not None and len(attributes) % 2 != 0:
-            print('Missing attribute values')
-            return False
-
         if command not in self.cli.get_commands():
             print('Command does not exist')
             return False

--- a/cli/rest.py
+++ b/cli/rest.py
@@ -28,6 +28,10 @@ class Rest():
 
         if command == 'job' and args == []:
             args = ['id', 'last']
+        elif re.findall(r'(job|device)', command):
+            if len(args) == 1 and re.match(r'[0-9]+', args[0]):
+                num_arg = args[0]
+                args = ['id', num_arg]
 
         # Make a dict of arguments and values
         args = dict(zip(args[::2], args[1::2]))

--- a/cnaas.yml
+++ b/cnaas.yml
@@ -35,7 +35,6 @@ cli:
           url_suffix: true
           show: true
           delete: true
-          mandatory: true
         - name: "hostname"
           description: 'Hostname'
         - name: "site_id"


### PR DESCRIPTION
Now possible to execute 'show' and 'no' command with out the id attribute. For example, instead of doing 'show device id 123' one can now do 'show device 123' and 'no device id 123' can be replaced with 'no device 123'.